### PR TITLE
ci: push tags and skip unnecessary rebases in sync workflow

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -46,8 +46,19 @@ jobs:
 
           spec_url="https://src.fedoraproject.org/rpms/selinux-policy/raw/f${FEDORA_VERSION}/f/selinux-policy.spec"
           stable_commit=$(curl -Ls "${spec_url}" | grep -E '^%global commit [0-9a-fA-F]+$')
-          git rebase "${stable_commit#%global commit }"
-          git push --follow-tags --force-with-lease
+          stable_commit="${stable_commit#%global commit }"
+          set +e
+          git merge-base --is-ancestor "${stable_commit}" HEAD
+          status=$?
+          set -e
+          case "${status}" in
+          0) ;;
+          1)
+            git rebase "${stable_commit}"
+            git push --follow-tags --force-with-lease
+            ;;
+          *) exit "${status}" ;;
+          esac
 
           readarray -t merged_tags < <(git tag -l "v${FEDORA_VERSION}.*" --merged)
           git push origin "${merged_tags[@]}"

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -48,3 +48,6 @@ jobs:
           stable_commit=$(curl -Ls "${spec_url}" | grep -E '^%global commit [0-9a-fA-F]+$')
           git rebase "${stable_commit#%global commit }"
           git push --follow-tags --force-with-lease
+
+          readarray -t merged_tags < <(git tag -l "v${FEDORA_VERSION}.*" --merged)
+          git push origin "${merged_tags[@]}"


### PR DESCRIPTION
Since `--follow-tags` only pushes annotated tags, we need to separately list merged tags and push them by name.

Also, if the commit we would rebase to is already present on the working branch, we skip the rebase since that means we wouldn't be pushing any new commits.